### PR TITLE
fix broken link in the guidelines folder

### DIFF
--- a/guidelines/CONTRIBUTING_en.md
+++ b/guidelines/CONTRIBUTING_en.md
@@ -43,6 +43,6 @@ For an overview of the labeling system we use to tag issues and pull requests, p
 Local Development
 ----------------------
 
-You can develop CSGHub using [Docker Compose](docs/all_in_one_readme_en.md) or your [local environment](docs/setup_en.md).
+You can develop CSGHub using [Docker Compose](https://github.com/OpenCSGs/csghub-installer/blob/main/docker-compose/csghub/README.md) or your [local environment](https://github.com/OpenCSGs/csghub/blob/main/docs/setup_en.md).  
 
 Thank you for contributing to the CSGHub project! We look forward to your involvement and suggestions.


### PR DESCRIPTION
fix broken link in the guidelines folder